### PR TITLE
Se elimina la dependencia innecesaria de mongo de los workflows de github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
-    services:
-      mongodb:
-        image: mongo:latest
-        ports:
-          - 27017:27017
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -16,11 +16,6 @@ jobs:
   test-node:
     name: Run node unit tests
     runs-on: ubuntu-latest
-    services:
-      mongodb:
-        image: mongo:latest
-        ports:
-          - 27017:27017
     strategy:
       matrix:
         service: [webapp, users, gatewayservice]


### PR DESCRIPTION
Dependencia remanente de versiones previas de la aplicación que incluía un contenedor de mongo en los test unitarios durante el workflow de github eliminada.