### PR TITLE
Corrección para abrir SwaggerUI en el gateway

### DIFF
--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -16,7 +16,11 @@ const gameyServiceUrl = process.env.GAMEY_SERVICE_URL || 'http://localhost:4000'
 
 const axios = require('axios');
 const app = express()
-app.use(helmet())
+app.use(helmet({
+  contentSecurityPolicy: false,
+  crossOriginEmbedderPolicy: false,
+  crossOriginOpenerPolicy: false
+}))
 app.use(cors())
 app.use(express.json())
 app.use(morgan('combined'))


### PR DESCRIPTION
Arregaldo politica Cross Origin Opener Policy para permitir que se abra SwaggerUI, ya que impedia que cargase la página.
