### PR TITLE
Añadida regla del pastel

### DIFF
--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -500,8 +500,8 @@ impl TryFrom<YEN> for GameY {
             });
         }
 
-        let mut b_coords: Vec<Coordinates> = Vec::new();
-        let mut r_coords: Vec<Coordinates> = Vec::new();
+        let mut ygame = GameY::new(size);
+        let mut winner: Option<PlayerId> = None;
 
         for (row, row_str) in rows.iter().enumerate() {
             let cells: Vec<char> = row_str.chars().collect();
@@ -517,10 +517,10 @@ impl TryFrom<YEN> for GameY {
                 let y = col as u32;
                 let z = size - 1 - x - y;
                 let coords = Coordinates::new(x, y, z);
-                match cell {
-                    'B' => b_coords.push(coords),
-                    'R' => r_coords.push(coords),
-                    '.' => {}
+                let player = match cell {
+                    'B' => Some(PlayerId::new(0)),
+                    'R' => Some(PlayerId::new(1)),
+                    '.' => None,
                     _ => {
                         return Err(GameYError::InvalidCharInLayout {
                             char: *cell,
@@ -528,52 +528,20 @@ impl TryFrom<YEN> for GameY {
                             col,
                         });
                     }
+                };
+
+                if let Some(player) = player {
+                    let set_idx = ygame.register_piece(player, coords);
+                    if ygame.connect_neighbors_and_check_win(coords, player, set_idx) {
+                        winner = Some(player);
+                    }
                 }
             }
         }
 
-        let mut ygame = GameY::new(size);
-        let mut b_index = 0usize;
-        let mut r_index = 0usize;
-
-        while b_index < b_coords.len() || r_index < r_coords.len() {
-            let next_player = match ygame.next_player() {
-                Some(player) => player.id(),
-                None => break,
-            };
-
-            if next_player == 0 {
-                if b_index >= b_coords.len() {
-                    return Err(GameYError::ServerError {
-                        message: "Invalid board: missing B move for expected turn".to_string(),
-                    });
-                }
-                ygame.add_move(Movement::Placement {
-                    player: PlayerId::new(0),
-                    coords: b_coords[b_index],
-                })?;
-                b_index += 1;
-            } else {
-                if r_index >= r_coords.len() {
-                    return Err(GameYError::ServerError {
-                        message: "Invalid board: missing R move for expected turn".to_string(),
-                    });
-                }
-                ygame.add_move(Movement::Placement {
-                    player: PlayerId::new(1),
-                    coords: r_coords[r_index],
-                })?;
-                r_index += 1;
-            }
-        }
-
-        if b_index != b_coords.len() || r_index != r_coords.len() {
-            return Err(GameYError::ServerError {
-                message: "Invalid board: extra moves remain after game end".to_string(),
-            });
-        }
-
-        if !ygame.check_game_over() {
+        if let Some(winner) = winner {
+            ygame.status = GameStatus::Finished { winner };
+        } else {
             ygame.status = GameStatus::Ongoing {
                 next_player: PlayerId::new(game.turn()),
             };

--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -140,7 +140,7 @@ impl GameY {
                 self.handle_placement(*player, *coords)?;
             }
             Movement::Action { player, action } => {
-                self.handle_action(*player, action);
+                self.handle_action(*player, action)?;
             }
         }
         self.history.push(movement);
@@ -203,19 +203,39 @@ impl GameY {
     }
 
     /// Handles non-placement actions (Resign, Swap, etc.)
-    fn handle_action(&mut self, player: PlayerId, action: &GameAction) {
+    fn handle_action(&mut self, player: PlayerId, action: &GameAction) -> Result<()> {
         match action {
             GameAction::Resign => {
                 self.status = GameStatus::Finished {
                     winner: other_player(player),
                 };
+                Ok(())
             }
             GameAction::Swap => {
+                self.apply_swap(player)?;
                 self.status = GameStatus::Ongoing {
-                    next_player: other_player(player),
+                    next_player: player,
                 };
+                Ok(())
             }
         }
+    }
+
+    fn apply_swap(&mut self, player: PlayerId) -> Result<()> {
+        let Some(Movement::Placement { player: opening_player, .. }) = self.history.first() else {
+            return Err(GameYError::ServerError {
+                message: "Swap is only allowed immediately after the opening move".to_string(),
+            });
+        };
+
+        if self.history.len() != 1 || opening_player.id() != 0 || player.id() != 1 {
+            return Err(GameYError::ServerError {
+                message: "Swap is only allowed for player 1 right after player 0 opens"
+                    .to_string(),
+            });
+        }
+
+        Ok(())
     }
 
     /// Handles validation logic (Game Over checks and Occupancy)
@@ -551,6 +571,12 @@ impl TryFrom<YEN> for GameY {
             return Err(GameYError::ServerError {
                 message: "Invalid board: extra moves remain after game end".to_string(),
             });
+        }
+
+        if !ygame.check_game_over() {
+            ygame.status = GameStatus::Ongoing {
+                next_player: PlayerId::new(game.turn()),
+            };
         }
 
         Ok(ygame)

--- a/gamey/src/game_server/play.rs
+++ b/gamey/src/game_server/play.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Coordinates, GameY, Movement, YEN,
+    Coordinates, GameAction, GameY, Movement, YEN,
     bot_server::{
         check_api_version,
         error::ErrorResponse,
@@ -21,8 +21,9 @@ pub struct MoveParams {
 #[derive(Deserialize)]
 pub struct MoveRequest {
     pub state: YEN,
-    pub row: u32,
-    pub col: u32,
+    pub row: Option<u32>,
+    pub col: Option<u32>,
+    pub action: Option<String>,
     pub bot_id: Option<String>,
     pub mode: Option<String>,
 }
@@ -48,27 +49,56 @@ pub async fn move_turn(
     let mut game =
         load_game_from_yen(request.state.clone(), &params.api_version, None).map_err(Json)?;
 
-    let size = game.board_size();
-    if request.row >= size || request.col > request.row {
-        return err_response(
-            "Invalid row/col for board size",
-            &params.api_version,
-            request.bot_id.clone(),
-        );
-    }
-
     if game.check_game_over() {
         return ok_response(&game, &params.api_version, None);
     }
 
-    let player_coords = row_col_to_coords(size, request.row, request.col);
     let moving_player = match game.next_player() {
         Some(player) => player,
         None => return ok_response(&game, &params.api_version, None),
     };
-    let player_move = Movement::Placement {
-        player: moving_player,
-        coords: player_coords,
+
+    let player_move = if let Some(action) = request.action.as_deref() {
+        match action.to_ascii_lowercase().as_str() {
+            "swap" => Movement::Action {
+                player: moving_player,
+                action: GameAction::Swap,
+            },
+            "resign" => Movement::Action {
+                player: moving_player,
+                action: GameAction::Resign,
+            },
+            _ => {
+                return err_response(
+                    "Unsupported action",
+                    &params.api_version,
+                    request.bot_id.clone(),
+                );
+            }
+        }
+    } else {
+        let (Some(row), Some(col)) = (request.row, request.col) else {
+            return err_response(
+                "row and col are required for placement moves",
+                &params.api_version,
+                request.bot_id.clone(),
+            );
+        };
+
+        let size = game.board_size();
+        if row >= size || col > row {
+            return err_response(
+                "Invalid row/col for board size",
+                &params.api_version,
+                request.bot_id.clone(),
+            );
+        }
+
+        let player_coords = row_col_to_coords(size, row, col);
+        Movement::Placement {
+            player: moving_player,
+            coords: player_coords,
+        }
     };
 
     if let Err(err) = game.add_move(player_move) {

--- a/gamey/tests/core_tests.rs
+++ b/gamey/tests/core_tests.rs
@@ -464,6 +464,29 @@ fn test_swap_is_rejected_before_opening_move() {
 }
 
 #[test]
+fn test_swap_is_rejected_after_second_move() {
+    let mut game = GameY::new(5);
+
+    game.add_move(Movement::Placement {
+        player: PlayerId::new(0),
+        coords: Coordinates::new(4, 0, 0),
+    })
+    .unwrap();
+    game.add_move(Movement::Placement {
+        player: PlayerId::new(1),
+        coords: Coordinates::new(3, 0, 1),
+    })
+    .unwrap();
+
+    let result = game.add_move(Movement::Action {
+        player: PlayerId::new(0),
+        action: GameAction::Swap,
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_yen_round_trip_after_swap() {
     let mut game = GameY::new(3);
 
@@ -489,6 +512,24 @@ fn test_yen_round_trip_after_swap() {
 
     assert_eq!(yen.layout(), reloaded_yen.layout());
     assert_eq!(yen.turn(), reloaded_yen.turn());
+}
+
+#[test]
+fn test_yen_load_preserves_turn_after_swap_position() {
+    let yen_str = r#"{
+        "size": 3,
+        "turn": 0,
+        "players": ["B","R"],
+        "layout": "B/R./..."
+    }"#;
+
+    let yen: YEN = serde_json::from_str(yen_str).unwrap();
+    let game = GameY::try_from(yen).unwrap();
+
+    assert!(!game.check_game_over());
+    assert_eq!(game.next_player(), Some(PlayerId::new(0)));
+    assert_eq!(game.cell_player(&Coordinates::new(2, 0, 0)), Some(PlayerId::new(0)));
+    assert_eq!(game.cell_player(&Coordinates::new(1, 0, 1)), Some(PlayerId::new(1)));
 }
 
 // ============================================================================

--- a/gamey/tests/core_tests.rs
+++ b/gamey/tests/core_tests.rs
@@ -464,6 +464,24 @@ fn test_swap_is_rejected_before_opening_move() {
 }
 
 #[test]
+fn test_swap_is_rejected_for_wrong_player_after_opening_move() {
+    let mut game = GameY::new(5);
+
+    game.add_move(Movement::Placement {
+        player: PlayerId::new(0),
+        coords: Coordinates::new(4, 0, 0),
+    })
+    .unwrap();
+
+    let result = game.add_move(Movement::Action {
+        player: PlayerId::new(0),
+        action: GameAction::Swap,
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_swap_is_rejected_after_second_move() {
     let mut game = GameY::new(5);
 

--- a/gamey/tests/core_tests.rs
+++ b/gamey/tests/core_tests.rs
@@ -411,8 +411,14 @@ fn test_player_1_resign_makes_player_0_win() {
 fn test_swap_changes_next_player() {
     let mut game = GameY::new(5);
 
-    game.add_move(Movement::Action {
+    game.add_move(Movement::Placement {
         player: PlayerId::new(0),
+        coords: Coordinates::new(4, 0, 0),
+    })
+    .unwrap();
+
+    game.add_move(Movement::Action {
+        player: PlayerId::new(1),
         action: GameAction::Swap,
     })
     .unwrap();
@@ -439,9 +445,50 @@ fn test_swap_after_opening_move() {
     })
     .unwrap();
 
-    // Now it's player 0's turn again
-    assert_eq!(game.next_player(), Some(PlayerId::new(0)));
+    // Now it remains color R's turn; externally the players have swapped colors
+    assert_eq!(game.next_player(), Some(PlayerId::new(1)));
     assert!(!game.check_game_over());
+    assert_eq!(game.cell_player(&Coordinates::new(2, 1, 1)), Some(PlayerId::new(0)));
+}
+
+#[test]
+fn test_swap_is_rejected_before_opening_move() {
+    let mut game = GameY::new(5);
+
+    let result = game.add_move(Movement::Action {
+        player: PlayerId::new(0),
+        action: GameAction::Swap,
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_yen_round_trip_after_swap() {
+    let mut game = GameY::new(3);
+
+    game.add_move(Movement::Placement {
+        player: PlayerId::new(0),
+        coords: Coordinates::new(2, 0, 0),
+    })
+    .unwrap();
+    game.add_move(Movement::Action {
+        player: PlayerId::new(1),
+        action: GameAction::Swap,
+    })
+    .unwrap();
+    game.add_move(Movement::Placement {
+        player: PlayerId::new(0),
+        coords: Coordinates::new(1, 0, 1),
+    })
+    .unwrap();
+
+    let yen: YEN = (&game).into();
+    let loaded = GameY::try_from(yen.clone()).unwrap();
+    let reloaded_yen: YEN = (&loaded).into();
+
+    assert_eq!(yen.layout(), reloaded_yen.layout());
+    assert_eq!(yen.turn(), reloaded_yen.turn());
 }
 
 // ============================================================================

--- a/webapp/src/__tests__/GamePage.test.tsx
+++ b/webapp/src/__tests__/GamePage.test.tsx
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+﻿import '@testing-library/jest-dom'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import GamePage from '../pages/GamePage'
@@ -116,6 +116,71 @@ it('debe llamar a la API de movimiento al hacer clic en una celda vacía', async
 			expect.objectContaining({ method: 'POST' }),
 		)
 	})
+})
+
+it('debe mostrar la regla del pastel tras la primera jugada en PvP', async () => {
+	; (useSession as Mock).mockReturnValue({ isLoggedIn: true })
+		; (useLocation as Mock).mockReturnValue({ state: { mode: 'pvp' } })
+
+		; (global.fetch as Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				game_over: false,
+				winner: null,
+				state: { size: 3, turn: 1, players: ['B', 'R'], layout: 'B/../...' },
+			}),
+		})
+
+	const { container } = render(<GamePage />)
+	const firstCell = container.querySelector('g')
+	fireEvent.click(firstCell!)
+
+	await waitFor(() => {
+		expect(screen.getByRole('button', { name: /Use Pie Rule/i })).toBeInTheDocument()
+	})
+})
+
+it('debe enviar la accion swap al aplicar la regla del pastel', async () => {
+	; (useSession as Mock).mockReturnValue({ isLoggedIn: true })
+		; (useLocation as Mock).mockReturnValue({ state: { mode: 'pvp' } })
+
+		; (global.fetch as Mock)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					game_over: false,
+					winner: null,
+					state: { size: 3, turn: 1, players: ['B', 'R'], layout: 'B/../...' },
+				}),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					game_over: false,
+					winner: null,
+					state: { size: 3, turn: 1, players: ['B', 'R'], layout: 'B/../...' },
+				}),
+			})
+
+	const { container } = render(<GamePage />)
+	const firstCell = container.querySelector('g')
+	fireEvent.click(firstCell!)
+
+	const pieRuleButton = await screen.findByRole('button', { name: /Use Pie Rule/i })
+	fireEvent.click(pieRuleButton)
+
+	await waitFor(() => {
+		expect(global.fetch).toHaveBeenNthCalledWith(
+			2,
+			expect.stringContaining('/game/move'),
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.stringContaining('"action":"swap"'),
+			}),
+		)
+	})
+
+	expect(screen.getByText('Player 1 turn.')).toBeInTheDocument()
 })
 
 it('debe resetear el tablero al hacer clic en "New Game"', () => {

--- a/webapp/src/__tests__/GamePage.test.tsx
+++ b/webapp/src/__tests__/GamePage.test.tsx
@@ -22,10 +22,8 @@ vi.mock('react-router-dom', () => ({
 }))
 
 // Mock de la función externa importada de GameSetup
-vi.mock('../utils/gameUtils', () => ({
+vi.mock('../pages/GameSetup', () => ({
 	getInitialBoardSize: vi.fn(() => 3),
-	minBoardSize: 3,
-	maxBoardSize: 15,
 }))
 
 // Mock de la API global fetch
@@ -136,7 +134,7 @@ it('debe mostrar la regla del pastel tras la primera jugada en PvP', async () =>
 	fireEvent.click(firstCell!)
 
 	await waitFor(() => {
-		expect(screen.getByRole('button', { name: /Use Pie Rule/i })).toBeInTheDocument()
+		expect(screen.getByRole('button', { name: /Swap/i })).toBeInTheDocument()
 	})
 })
 
@@ -166,7 +164,7 @@ it('debe enviar la accion swap al aplicar la regla del pastel', async () => {
 	const firstCell = container.querySelector('g')
 	fireEvent.click(firstCell!)
 
-	const pieRuleButton = await screen.findByRole('button', { name: /Use Pie Rule/i })
+	const pieRuleButton = await screen.findByRole('button', { name: /Swap/i })
 	fireEvent.click(pieRuleButton)
 
 	await waitFor(() => {
@@ -180,7 +178,10 @@ it('debe enviar la accion swap al aplicar la regla del pastel', async () => {
 		)
 	})
 
-	expect(screen.getByText('Player 1 turn.')).toBeInTheDocument()
+	await waitFor(() => {
+		expect(screen.getByText('Player 1')).toBeInTheDocument()
+		expect(screen.getByText('Player 2')).toBeInTheDocument()
+	})
 })
 
 it('debe resetear el tablero al hacer clic en "New Game"', () => {
@@ -192,8 +193,9 @@ it('debe resetear el tablero al hacer clic en "New Game"', () => {
 	const newGameButton = screen.getByRole('button', { name: /New Game/i })
 	fireEvent.click(newGameButton)
 
-	// Si se resetea, el mensaje vuelve al turno inicial
-	expect(screen.getByText('Your turn. Place a piece.')).toBeInTheDocument()
+	expect(screen.getByRole('img', { name: /Y game board/i })).toBeInTheDocument()
+	expect(screen.getByText('You')).toBeInTheDocument()
+	expect(screen.getByText('Bot')).toBeInTheDocument()
 })
 
 it('debe navegar a /homepage al hacer clic en "Back to Home"', () => {
@@ -280,7 +282,7 @@ it('debe mostrar el ganador correcto cuando finaliza el juego (Gana Player 1)', 
 	fireEvent.click(firstCell!)
 
 	await waitFor(() => {
-		expect(screen.getByText('Player 1 wins.')).toBeInTheDocument()
+		expect(screen.getByText('Player 1 wins!')).toBeInTheDocument()
 	})
 })
 
@@ -313,7 +315,7 @@ it('debe mostrar el ganador correcto cuando el Bot gana (Gana R en modo bot)', a
 
 	// Aumentamos el timeout del waitFor porque el modo bot tiene un delay artificial (botDelayMs = 700)
 	await waitFor(() => {
-		expect(screen.getByText('Bot wins.')).toBeInTheDocument()
+		expect(screen.getByText('Oh no! The bot won')).toBeInTheDocument()
 	}, { timeout: 1500 })
 })
 

--- a/webapp/src/__tests__/GamePage.test.tsx
+++ b/webapp/src/__tests__/GamePage.test.tsx
@@ -72,8 +72,8 @@ it('debe renderizar el tablero en modo bot por defecto si está logueado', async
 	// Verifica que el título corresponda al modo bot
 	expect(screen.getByText('Game Y - Player vs Bot')).toBeInTheDocument()
 
-	// Verifica que el SVG del tablero se haya renderizado
-	expect(screen.getByRole('img', { name: /Y game board/i })).toBeInTheDocument()
+	expect(screen.getByText('You')).toBeInTheDocument()
+	expect(screen.getByText('Bot')).toBeInTheDocument()
 })
 
 it('debe renderizar en modo pvp si se pasa por el estado de navegación', () => {
@@ -83,6 +83,9 @@ it('debe renderizar en modo pvp si se pasa por el estado de navegación', () => 
 	render(<GamePage />)
 
 	expect(screen.getByText('Game Y - Player vs Player')).toBeInTheDocument()
+	expect(screen.getByText('Player 1')).toBeInTheDocument()
+	expect(screen.getByText('Player 2')).toBeInTheDocument()
+	expect(screen.queryByRole('button', { name: /Swap/i })).not.toBeInTheDocument()
 })
 
 it('debe llamar a la API de movimiento al hacer clic en una celda vacía', async () => {
@@ -193,9 +196,9 @@ it('debe resetear el tablero al hacer clic en "New Game"', () => {
 	const newGameButton = screen.getByRole('button', { name: /New Game/i })
 	fireEvent.click(newGameButton)
 
-	expect(screen.getByRole('img', { name: /Y game board/i })).toBeInTheDocument()
 	expect(screen.getByText('You')).toBeInTheDocument()
 	expect(screen.getByText('Bot')).toBeInTheDocument()
+	expect(screen.queryByRole('button', { name: /Swap/i })).not.toBeInTheDocument()
 })
 
 it('debe navegar a /homepage al hacer clic en "Back to Home"', () => {
@@ -256,6 +259,36 @@ it('debe manejar errores si la API falla al intentar hacer un movimiento', async
 	// Se debe atrapar el error, mostrar el mensaje del backend
 	await waitFor(() => {
 		expect(screen.getByText('Movimiento inválido')).toBeInTheDocument()
+	})
+})
+
+it('debe mostrar error si falla el swap', async () => {
+	; (useSession as Mock).mockReturnValue({ isLoggedIn: true })
+		; (useLocation as Mock).mockReturnValue({ state: { mode: 'pvp' } })
+
+		; (global.fetch as Mock)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					game_over: false,
+					winner: null,
+					state: { size: 3, turn: 1, players: ['B', 'R'], layout: 'B/../...' },
+				}),
+			})
+			.mockResolvedValueOnce({
+				ok: false,
+				json: async () => ({ error: 'Swap inválido' }),
+			})
+
+	const { container } = render(<GamePage />)
+	const firstCell = container.querySelector('g')
+	fireEvent.click(firstCell!)
+
+	const swapButton = await screen.findByRole('button', { name: /Swap/i })
+	fireEvent.click(swapButton)
+
+	await waitFor(() => {
+		expect(screen.getByText('Swap inválido')).toBeInTheDocument()
 	})
 })
 

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -264,9 +264,9 @@ export default function GamePage() {
             width={triangle.width}
             height={triangle.height}
             viewBox={`0 0 ${triangle.width} ${triangle.height}`}
-            role="img"
             aria-label={`${label} triangle`}
           >
+            <title>{`${label} triangle`}</title>
             <polygon
               points={`${triangle.top.x},${triangle.top.y} ${triangle.left.x},${triangle.left.y} ${triangle.right.x},${triangle.right.y}`}
               fill={isWinner ? winningFill : fill}
@@ -522,7 +522,8 @@ export default function GamePage() {
           </Box>
 
           <Box sx={{ width: '100%', maxWidth: 560, p: 2 }}>
-            <svg viewBox={`0 0 ${svgWidth} ${svgHeight}`} width="100%" role="img" aria-label="Y game board">
+            <svg viewBox={`0 0 ${svgWidth} ${svgHeight}`} width="100%" aria-label="Y game board">
+              <title>Y game board</title>
 
               {board.map((row, rowIndex) =>
                 row.map((cell, cellIndex) => {

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -42,10 +42,10 @@ function cloneBoard(board: Board): Board {
   return board.map((row) => [...row])
 }
 
-function toYen(board: Board) {
+function toYen(board: Board, currentPlayer: 'B' | 'R') {
   return {
     size: board.length,
-    turn: 0,
+    turn: currentPlayer === 'B' ? 0 : 1,
     players: ['B', 'R'],
     layout: board.map((row) => row.join('')).join('/'),
   }
@@ -91,6 +91,24 @@ function boardFromLayout(size: number, layout: string): Board {
   return board
 }
 
+function countPieces(board: Board): number {
+  return board.reduce(
+    (total, row) => total + row.filter((cell) => cell !== '.').length,
+    0,
+  )
+}
+
+function getTriangleVertices(size = 74) {
+  const height = size * 0.86
+  return {
+    top: { x: size / 2, y: 8 },
+    left: { x: 10, y: height },
+    right: { x: size - 10, y: height },
+    width: size,
+    height: height + 10,
+  }
+}
+
 export default function GamePage() {
   const navigate = useNavigate()
   const location = useLocation()
@@ -109,6 +127,8 @@ export default function GamePage() {
   const difficulty = state?.difficulty ?? 'Medium'
   const bot_id     = state?.bot_id     ?? 'random_bot'
   const [currentPlayer, setCurrentPlayer] = useState<'B' | 'R'>('B')
+  const [playerOneColor, setPlayerOneColor] = useState<'B' | 'R'>('B')
+  const [playerTwoColor, setPlayerTwoColor] = useState<'B' | 'R'>('R')
   const [message, setMessage] = useState(mode === 'pvp' ? 'Player 1 turn.' : 'Your turn. Place a piece.')
   const [error, setError] = useState('')
   const { isLoggedIn } = useSession();
@@ -136,6 +156,90 @@ export default function GamePage() {
     return <Navigate to="/login" replace />;
   }
 
+  const getPvpPlayerLabel = (color: 'B' | 'R', p1Color = playerOneColor, p2Color = playerTwoColor) => {
+    if (color === p1Color) {
+      return 'Player 1'
+    }
+    if (color === p2Color) {
+      return 'Player 2'
+    }
+    return `Player ${color}`
+  }
+
+  const pieceCount = countPieces(board)
+  const canUsePieRule =
+    mode === 'pvp' &&
+    !busy &&
+    winner === null &&
+    pieceCount === 1 &&
+    currentPlayer === playerTwoColor &&
+    playerOneColor === 'B' &&
+    playerTwoColor === 'R'
+  const playerOneActive = currentPlayer === playerOneColor
+  const playerTwoActive = currentPlayer === playerTwoColor
+  const playerOneLabel = mode === 'pvp' ? 'Player 1' : 'You'
+  const playerTwoLabel = mode === 'pvp' ? 'Player 2' : 'Bot'
+
+  const renderPlayerTriangle = (label: string, color: 'B' | 'R', isActive: boolean) => {
+    const triangle = getTriangleVertices()
+    const stroke = color === 'B' ? '#1565c0' : '#c62828'
+    const fill = color === 'B' ? 'rgba(21, 101, 192, 0.14)' : 'rgba(198, 40, 40, 0.14)'
+
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          flex: 1,
+          minWidth: 180,
+          p: 1.5,
+          borderRadius: 3,
+          border: `2px solid ${isActive ? stroke : 'rgba(15, 23, 42, 0.14)'}`,
+          backgroundColor: '#fff',
+        }}
+      >
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.75 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            {label}
+          </Typography>
+          <Box
+            sx={{
+              px: 1,
+              py: 0.35,
+              borderRadius: 999,
+              bgcolor: isActive ? stroke : 'rgba(15, 23, 42, 0.08)',
+              color: isActive ? '#fff' : 'text.secondary',
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {isActive ? 'Turn' : 'Waiting'}
+          </Box>
+        </Stack>
+
+        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+          <svg
+            width={triangle.width}
+            height={triangle.height}
+            viewBox={`0 0 ${triangle.width} ${triangle.height}`}
+            role="img"
+            aria-label={`${label} triangle`}
+          >
+            <polygon
+              points={`${triangle.top.x},${triangle.top.y} ${triangle.left.x},${triangle.left.y} ${triangle.right.x},${triangle.right.y}`}
+              fill={fill}
+              stroke="transparent"
+            />
+            <line x1={triangle.top.x} y1={triangle.top.y} x2={triangle.left.x} y2={triangle.left.y} stroke={stroke} strokeWidth={6} strokeLinecap="round" />
+            <line x1={triangle.left.x} y1={triangle.left.y} x2={triangle.right.x} y2={triangle.right.y} stroke={stroke} strokeWidth={6} strokeLinecap="round" />
+            <line x1={triangle.right.x} y1={triangle.right.y} x2={triangle.top.x} y2={triangle.top.y} stroke={stroke} strokeWidth={6} strokeLinecap="round" />
+          </svg>
+        </Box>
+      </Paper>
+    )
+  }
+
   const play = async (row: number, col: number) => {
     if (!isAvailable || busy || winner !== null || board[row][col] !== '.') {
       if (!isAvailable) {
@@ -160,7 +264,7 @@ export default function GamePage() {
       setMessage(mode === 'pvp' ? 'Processing move...' : 'Bot is thinking...')
 
       const payload: Record<string, unknown> = {
-        state: toYen(previousBoard),
+        state: toYen(previousBoard, currentPlayer),
         row,
         col,
         mode,
@@ -182,6 +286,7 @@ export default function GamePage() {
       }
 
       if (mode === 'bot') {
+        setCurrentPlayer('R')
         await delay(botDelayMs)
       }
 
@@ -211,9 +316,9 @@ export default function GamePage() {
         });
         
         if (finalWinner === 'B') {
-          setMessage(mode === 'pvp' ? 'Player 1 wins.' : 'You win.')
+          setMessage(mode === 'pvp' ? `${getPvpPlayerLabel('B')} wins.` : 'You win.')
         } else if (finalWinner === 'R') {
-          setMessage(mode === 'pvp' ? 'Player 2 wins.' : 'Bot wins.')
+          setMessage(mode === 'pvp' ? `${getPvpPlayerLabel('R')} wins.` : 'Bot wins.')
         } else {
           setMessage('Game Over.')
         }
@@ -223,8 +328,9 @@ export default function GamePage() {
         if (mode === 'pvp') {
           const nextPlayer = moveData.state.turn === 0 ? 'B' : 'R'
           setCurrentPlayer(nextPlayer)
-          setMessage(`Player ${nextPlayer} turn.`)
+          setMessage(`${getPvpPlayerLabel(nextPlayer)} turn.`)
         } else {
+          setCurrentPlayer('B')
           setMessage('Your turn. Place a piece.')
         }
       }
@@ -238,6 +344,51 @@ export default function GamePage() {
     }
   }
 
+  const swapSides = async () => {
+    if (!canUsePieRule) {
+      return
+    }
+
+    setBusy(true)
+    setError('')
+    setMessage('Applying pie rule...')
+
+    try {
+      const response = await fetch(`${apiEndpoint}/game/move`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          state: toYen(board, currentPlayer),
+          action: 'swap',
+          mode,
+        }),
+      })
+
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Unable to apply pie rule')
+      }
+
+      const moveData = data as MoveTurnResponse
+      const updated = boardFromLayout(moveData.state.size, moveData.state.layout)
+      const nextPlayer = moveData.state.turn === 0 ? 'B' : 'R'
+      const nextPlayerOneColor: 'B' | 'R' = 'R'
+      const nextPlayerTwoColor: 'B' | 'R' = 'B'
+
+      setBoard(updated)
+      setPlayerOneColor(nextPlayerOneColor)
+      setPlayerTwoColor(nextPlayerTwoColor)
+      setCurrentPlayer(nextPlayer)
+      setMessage(`${getPvpPlayerLabel(nextPlayer, nextPlayerOneColor, nextPlayerTwoColor)} turn.`)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unknown error'
+      setError(msg)
+      setMessage('The pie rule could not be applied.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const reset = () => {
     setBoard(makeEmptyBoard(boardSize))
     setBusy(false)
@@ -245,24 +396,11 @@ export default function GamePage() {
     setStartTime(null)
     setIsGameOver(false)
     setCurrentPlayer('B')
+    setPlayerOneColor('B')
+    setPlayerTwoColor('R')
     setError('')
     setMessage(mode === 'pvp' ? 'Player 1 turn.' : 'Your turn. Place a piece.')
   }
-
-  /* Actualmente sin usar, para usar importar minBoardSize y maxBoardSize de GameSetup
-  const handleSizeChange = (newSize: number) => {
-    if (newSize >= minBoardSize && newSize <= maxBoardSize) {
-      setBoardSize(newSize)
-      sessionStorage.setItem('boardSize', newSize.toString())
-      setBoard(makeEmptyBoard(newSize))
-      setBusy(false)
-      setWinner(null)
-      setCurrentPlayer('B')
-      setError('')
-      setMessage(mode === 'pvp' ? 'Player 1 turn.' : 'Your turn. Place a piece.')
-    }
-  }
-  */
 
   const svgWidth = svgPadding * 2 + (boardSize - 1) * horizontalGap
   const svgHeight = svgPadding * 2 + (boardSize - 1) * verticalGap
@@ -270,8 +408,9 @@ export default function GamePage() {
   // Lógica para el contenido del diálogo de fin de partida
   const isPvP = mode === 'pvp';
   const userWon = winner === 'B';
+  const winnerLabel = winner ? getPvpPlayerLabel(winner) : 'Player';
   const dialogTitle = isPvP 
-    ? `Player ${winner === 'B' ? 'B' : 'R'} wins!` 
+    ? `${winnerLabel} wins!` 
     : (userWon ? 'Congratulations, you won!' : 'Oh no! The bot won');
   
   const accentColor = isPvP 
@@ -280,17 +419,44 @@ export default function GamePage() {
 
   return (
     <div className="main-content">
-      <Paper elevation={3} sx={{ p: 4, maxWidth: 900, width: '100%' }}>
+      <Paper
+        elevation={0}
+        sx={{
+          p: 4,
+          maxWidth: 1080,
+          width: '100%',
+          borderRadius: 4,
+          backgroundColor: '#0f172a',
+          color: '#f8fafc',
+          border: '1px solid rgba(148, 163, 184, 0.18)',
+        }}
+      >
         <Typography variant="h4" component="h2" gutterBottom>
           Game Y - {mode === 'pvp' ? 'Player vs Player' : 'Player vs Bot'}
         </Typography>
 
-        <Alert severity={error ? 'warning' : 'info'} sx={{ mb: 3 }}>
-          {error || message}
-        </Alert>
+        {error && (
+          <Alert severity={error ? 'warning' : 'info'} sx={{ mb: 3 }}>
+            {error || message}
+          </Alert>
+        )}
 
-        <Box sx={{ mb: 4, width: '100%', display: 'flex', justifyContent: 'center' }}>
-          <Box sx={{ width: '100%', maxWidth: 560, background: '#ffffff', p: 2 }}>
+        <Box
+          sx={{
+            mb: 4,
+            width: '100%',
+            display: 'flex',
+            flexDirection: { xs: 'column', lg: 'row' },
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 2,
+          }}
+        >
+          <Box sx={{ width: { xs: '100%', lg: 210 }, flexShrink: 0 }}>
+            {renderPlayerTriangle(playerOneLabel, playerOneColor, playerOneActive)}
+          </Box>
+
+          <Box sx={{ width: '100%', maxWidth: 560, p: 2 }}>
             <svg viewBox={`0 0 ${svgWidth} ${svgHeight}`} width="100%" role="img" aria-label="Y game board">
 
               {board.map((row, rowIndex) =>
@@ -332,13 +498,32 @@ export default function GamePage() {
               )}
             </svg>
           </Box>
+
+          <Box sx={{ width: { xs: '100%', lg: 210 }, flexShrink: 0 }}>
+            {renderPlayerTriangle(playerTwoLabel, playerTwoColor, playerTwoActive)}
+            {canUsePieRule && (
+              <Button
+                variant="contained"
+                onClick={swapSides}
+                sx={{
+                  mt: 1.25,
+                  width: '100%',
+                  bgcolor: '#f8fafc',
+                  color: '#0f172a',
+                  '&:hover': { bgcolor: '#e2e8f0' },
+                }}
+              >
+                Swap
+              </Button>
+            )}
+          </Box>
         </Box>
 
         <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
-          <Button variant="outlined" onClick={reset}>
+          <Button variant="outlined" onClick={reset} sx={{ color: '#f8fafc', borderColor: '#f8fafc' }}>
             New Game
           </Button>
-          <Button variant="outlined" onClick={() => navigate('/homepage')}>
+          <Button variant="outlined" onClick={() => navigate('/homepage')} sx={{ color: '#f8fafc', borderColor: '#f8fafc' }}>
             Back to Home
           </Button>
         </Box>
@@ -377,7 +562,7 @@ export default function GamePage() {
             )}
             <Typography variant="body1" color="text.secondary">
               {isPvP 
-                ? `The game has ended. Player ${winner === 'B' ? 'blue' : 'red'} wins.`
+                ? `The game has ended. ${winnerLabel} wins.`
                 : (userWon 
                     ? 'You outsmarted the bot. Great play!' 
                     : 'The bot was smarter this time. Wanna try again?')

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -98,6 +98,37 @@ function countPieces(board: Board): number {
   )
 }
 
+function getTouchedSides(board: Board, color: 'B' | 'R') {
+  const size = board.length
+  let touchesA = false
+  let touchesB = false
+  let touchesC = false
+
+  for (let row = 0; row < size; row++) {
+    for (let col = 0; col <= row; col++) {
+      if (board[row][col] !== color) {
+        continue
+      }
+
+      const x = size - 1 - row
+      const y = col
+      const z = row - col
+
+      if (x === 0) {
+        touchesA = true
+      }
+      if (y === 0) {
+        touchesB = true
+      }
+      if (z === 0) {
+        touchesC = true
+      }
+    }
+  }
+
+  return { touchesA, touchesB, touchesC }
+}
+
 function getTriangleVertices(size = 74) {
   const height = size * 0.86
   return {
@@ -179,11 +210,21 @@ export default function GamePage() {
   const playerTwoActive = currentPlayer === playerTwoColor
   const playerOneLabel = mode === 'pvp' ? 'Player 1' : 'You'
   const playerTwoLabel = mode === 'pvp' ? 'Player 2' : 'Bot'
+  const playerOneSides = getTouchedSides(board, playerOneColor)
+  const playerTwoSides = getTouchedSides(board, playerTwoColor)
 
-  const renderPlayerTriangle = (label: string, color: 'B' | 'R', isActive: boolean) => {
+  const renderPlayerTriangle = (
+    label: string,
+    color: 'B' | 'R',
+    isActive: boolean,
+    touchedSides: { touchesA: boolean; touchesB: boolean; touchesC: boolean },
+  ) => {
     const triangle = getTriangleVertices()
     const stroke = color === 'B' ? '#1565c0' : '#c62828'
     const fill = color === 'B' ? 'rgba(21, 101, 192, 0.14)' : 'rgba(198, 40, 40, 0.14)'
+    const winningFill = color === 'B' ? 'rgba(21, 101, 192, 0.82)' : 'rgba(198, 40, 40, 0.82)'
+    const inactiveStroke = 'rgba(148, 163, 184, 0.45)'
+    const isWinner = winner === color
 
     return (
       <Paper
@@ -228,12 +269,36 @@ export default function GamePage() {
           >
             <polygon
               points={`${triangle.top.x},${triangle.top.y} ${triangle.left.x},${triangle.left.y} ${triangle.right.x},${triangle.right.y}`}
-              fill={fill}
+              fill={isWinner ? winningFill : fill}
               stroke="transparent"
             />
-            <line x1={triangle.top.x} y1={triangle.top.y} x2={triangle.left.x} y2={triangle.left.y} stroke={stroke} strokeWidth={6} strokeLinecap="round" />
-            <line x1={triangle.left.x} y1={triangle.left.y} x2={triangle.right.x} y2={triangle.right.y} stroke={stroke} strokeWidth={6} strokeLinecap="round" />
-            <line x1={triangle.right.x} y1={triangle.right.y} x2={triangle.top.x} y2={triangle.top.y} stroke={stroke} strokeWidth={6} strokeLinecap="round" />
+            <line
+              x1={triangle.top.x}
+              y1={triangle.top.y}
+              x2={triangle.left.x}
+              y2={triangle.left.y}
+              stroke={touchedSides.touchesB ? stroke : inactiveStroke}
+              strokeWidth={6}
+              strokeLinecap="round"
+            />
+            <line
+              x1={triangle.left.x}
+              y1={triangle.left.y}
+              x2={triangle.right.x}
+              y2={triangle.right.y}
+              stroke={touchedSides.touchesA ? stroke : inactiveStroke}
+              strokeWidth={6}
+              strokeLinecap="round"
+            />
+            <line
+              x1={triangle.right.x}
+              y1={triangle.right.y}
+              x2={triangle.top.x}
+              y2={triangle.top.y}
+              stroke={touchedSides.touchesC ? stroke : inactiveStroke}
+              strokeWidth={6}
+              strokeLinecap="round"
+            />
           </svg>
         </Box>
       </Paper>
@@ -453,7 +518,7 @@ export default function GamePage() {
           }}
         >
           <Box sx={{ width: { xs: '100%', lg: 210 }, flexShrink: 0 }}>
-            {renderPlayerTriangle(playerOneLabel, playerOneColor, playerOneActive)}
+            {renderPlayerTriangle(playerOneLabel, playerOneColor, playerOneActive, playerOneSides)}
           </Box>
 
           <Box sx={{ width: '100%', maxWidth: 560, p: 2 }}>
@@ -500,7 +565,7 @@ export default function GamePage() {
           </Box>
 
           <Box sx={{ width: { xs: '100%', lg: 210 }, flexShrink: 0 }}>
-            {renderPlayerTriangle(playerTwoLabel, playerTwoColor, playerTwoActive)}
+            {renderPlayerTriangle(playerTwoLabel, playerTwoColor, playerTwoActive, playerTwoSides)}
             {canUsePieRule && (
               <Button
                 variant="contained"


### PR DESCRIPTION
- Se implementa la lógica del swap para la regla del pastel en el core del juego y en el endpoint de movimiento.
- Se actualizan los tests del core para cubrir el nuevo comportamiento del swap.
- Se adapta la interfaz de GamePage para mostrar de forma mas clara el estado de la partida, integrando indicadores visuales de turno y swap.
- Se actualizan los tests de GamePage para cubrir la nueva interfaz visual y el swap.