### PR TITLE
Api bot

### DIFF
--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -6,7 +6,7 @@
 //! # Endpoints
 //! - `GET /status` - Health check endpoint
 //! - `POST /{api_version}/ybot/choose/{bot_id}` - Request a move from a bot
-//! - `POST /{api_version}/ybot/play` - Apply a bot move and return the resulting YEN position
+//! - `GET /{api_version}/ybot/play` - Request the next move for a public bot
 //!
 //! # Example
 //! ```no_run
@@ -52,7 +52,7 @@ pub fn create_router(state: AppState) -> axum::Router {
         )
         .route(
             "/{api_version}/ybot/play",
-            axum::routing::post(play::play),
+            axum::routing::get(play::play),
         )
         .layer(cors)
         .with_state(state)

--- a/gamey/src/bot_server/play.rs
+++ b/gamey/src/bot_server/play.rs
@@ -1,15 +1,15 @@
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
 };
 use serde::Deserialize;
 
-use crate::{YEN, check_api_version};
+use crate::{Coordinates, check_api_version};
 
 use super::{
     error::ErrorResponse,
     service::{
-        apply_bot_turn, find_registered_bot, load_game_from_yen, resolve_public_bot_selection,
+        choose_move_or_error, find_registered_bot, load_game_from_yen, resolve_public_bot_selection,
     },
     state::AppState,
 };
@@ -20,56 +20,47 @@ pub struct PlayParams {
 }
 
 #[derive(Deserialize)]
-#[serde(untagged)]
-pub enum PlayRequest {
-    Position(YEN),
-    WithOptions {
-        position: YEN,
-        bot_id: Option<String>,
-        difficulty: Option<String>,
-    },
+pub struct PlayQuery {
+    position: String,
+    bot_id: Option<String>,
 }
 
-impl PlayRequest {
-    fn into_parts(self) -> (YEN, Option<String>, Option<String>) {
-        match self {
-            PlayRequest::Position(position) => (position, None, None),
-            PlayRequest::WithOptions {
-                position,
-                bot_id,
-                difficulty,
-            } => (position, bot_id, difficulty),
-        }
-    }
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct PlayResponse {
+    pub coords: Coordinates,
 }
-
-pub type PlayResponse = YEN;
 
 #[axum::debug_handler]
 pub async fn play(
     State(state): State<AppState>,
     Path(params): Path<PlayParams>,
-    Json(request): Json<PlayRequest>,
+    Query(query): Query<PlayQuery>,
 ) -> Result<Json<PlayResponse>, ErrorResponse> {
     check_api_version(&params.api_version)?;
-    let (position, bot_id, difficulty) = request.into_parts();
-
-    let selection = resolve_public_bot_selection(bot_id.as_deref(), difficulty.as_deref())
-    .map_err(|error| ErrorResponse {
-        api_version: Some(params.api_version.clone()),
-        ..error
+    let position = serde_json::from_str(&query.position).map_err(|error| {
+        ErrorResponse::error(
+            &format!("Invalid YEN format: {}", error),
+            Some(params.api_version.clone()),
+            query.bot_id.clone(),
+        )
     })?;
 
-    let mut game = load_game_from_yen(position, &params.api_version, Some(&selection.public_bot_id))?;
+    let selection =
+        resolve_public_bot_selection(query.bot_id.as_deref()).map_err(|error| ErrorResponse {
+            api_version: Some(params.api_version.clone()),
+            ..error
+        })?;
+
+    let game = load_game_from_yen(position, &params.api_version, Some(&selection.public_bot_id))?;
 
     let bot = find_registered_bot(&state, &params.api_version, &selection.registry_bot_id)?;
 
-    apply_bot_turn(
+    let coords = choose_move_or_error(
         bot.as_ref(),
-        &mut game,
+        &game,
         &params.api_version,
         &selection.registry_bot_id,
     )?;
 
-    Ok(Json((&game).into()))
+    Ok(Json(PlayResponse { coords }))
 }

--- a/gamey/src/bot_server/service.rs
+++ b/gamey/src/bot_server/service.rs
@@ -4,22 +4,18 @@ use crate::{Coordinates, GameStatus, GameY, Movement, YBot, YEN};
 
 use super::{error::ErrorResponse, state::AppState};
 
-pub const DEFAULT_PUBLIC_BOT_ID: &str = "center_bot";
-pub const DEFAULT_PUBLIC_DIFFICULTY: &str = "Hard";
+pub const DEFAULT_PUBLIC_BOT_ID: &str = "alpha_bot";
 
-const VALID_PUBLIC_BOTS: [&str; 4] = ["random_bot", "center_bot", "edge_bot", "mirror_bot"];
-const VALID_DIFFICULTIES: [&str; 3] = ["Easy", "Medium", "Hard"];
+const VALID_PUBLIC_BOTS: [&str; 2] = ["alpha_bot", "smart_bot"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotSelection {
     pub public_bot_id: String,
-    pub difficulty: String,
     pub registry_bot_id: String,
 }
 
 pub fn resolve_public_bot_selection(
     bot_id: Option<&str>,
-    difficulty: Option<&str>,
 ) -> Result<BotSelection, ErrorResponse> {
     let public_bot_id = bot_id.unwrap_or(DEFAULT_PUBLIC_BOT_ID).trim();
     if !VALID_PUBLIC_BOTS.contains(&public_bot_id) {
@@ -30,25 +26,9 @@ pub fn resolve_public_bot_selection(
         ));
     }
 
-    let difficulty = difficulty.unwrap_or(DEFAULT_PUBLIC_DIFFICULTY).trim();
-    if !VALID_DIFFICULTIES.contains(&difficulty) {
-        return Err(ErrorResponse::error(
-            &format!("Unknown difficulty: {}", difficulty),
-            None,
-            Some(public_bot_id.to_string()),
-        ));
-    }
-
-    let suffix = match difficulty {
-        "Easy" => "_1",
-        "Medium" => "_2",
-        _ => "",
-    };
-
     Ok(BotSelection {
         public_bot_id: public_bot_id.to_string(),
-        difficulty: difficulty.to_string(),
-        registry_bot_id: format!("{}{}", public_bot_id, suffix),
+        registry_bot_id: public_bot_id.to_string(),
     })
 }
 
@@ -139,7 +119,7 @@ pub fn winner_char(game: &GameY) -> Option<char> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CenterBot, PlayerId, RandomBot, YBotRegistry};
+    use crate::{AlphaBot, PlayerId, RandomBot, YBotRegistry};
 
     struct NoMoveBot;
 
@@ -155,42 +135,34 @@ mod tests {
 
     #[test]
     fn test_resolve_public_bot_selection_uses_defaults() {
-        let selection = resolve_public_bot_selection(None, None).unwrap();
-        assert_eq!(selection.public_bot_id, "center_bot");
-        assert_eq!(selection.difficulty, "Hard");
-        assert_eq!(selection.registry_bot_id, "center_bot");
+        let selection = resolve_public_bot_selection(None).unwrap();
+        assert_eq!(selection.public_bot_id, "alpha_bot");
+        assert_eq!(selection.registry_bot_id, "alpha_bot");
     }
 
     #[test]
-    fn test_resolve_public_bot_selection_with_medium_suffix() {
-        let selection = resolve_public_bot_selection(Some("random_bot"), Some("Medium")).unwrap();
-        assert_eq!(selection.registry_bot_id, "random_bot_2");
-    }
-
-    #[test]
-    fn test_resolve_public_bot_selection_rejects_unknown_difficulty() {
-        let error = resolve_public_bot_selection(Some("center_bot"), Some("Impossible"))
-            .unwrap_err();
-        assert!(error.message.contains("Unknown difficulty"));
+    fn test_resolve_public_bot_selection_with_explicit_smart_bot() {
+        let selection = resolve_public_bot_selection(Some("smart_bot")).unwrap();
+        assert_eq!(selection.registry_bot_id, "smart_bot");
     }
 
     #[test]
     fn test_resolve_public_bot_selection_rejects_unknown_bot() {
-        let error = resolve_public_bot_selection(Some("unknown_bot"), Some("Hard")).unwrap_err();
+        let error = resolve_public_bot_selection(Some("unknown_bot")).unwrap_err();
         assert!(error.message.contains("Unknown bot_id"));
     }
 
     #[test]
     fn test_find_registered_bot_returns_registered_instance() {
-        let state = AppState::new(YBotRegistry::new().with_bot(Arc::new(CenterBot { level: 3 })));
-        let bot = find_registered_bot(&state, "v1", "center_bot").unwrap();
-        assert_eq!(bot.name(), "center_bot");
+        let state = AppState::new(YBotRegistry::new().with_bot(Arc::new(AlphaBot { level: 3 })));
+        let bot = find_registered_bot(&state, "v1", "alpha_bot").unwrap();
+        assert_eq!(bot.name(), "alpha_bot");
     }
 
     #[test]
     fn test_load_game_from_yen_rejects_invalid_layout() {
         let yen = YEN::new(3, 0, vec!['B', 'R'], "invalid".to_string());
-        let error = load_game_from_yen(yen, "v1", Some("center_bot")).unwrap_err();
+        let error = load_game_from_yen(yen, "v1", Some("smart_bot")).unwrap_err();
         assert!(error.message.contains("Invalid YEN format"));
         assert_eq!(error.api_version, Some("v1".to_string()));
     }

--- a/gamey/src/game_server/mod.rs
+++ b/gamey/src/game_server/mod.rs
@@ -24,7 +24,7 @@ pub fn create_router(state: AppState) -> axum::Router {
         )
         .route(
             "/{api_version}/ybot/play",
-            axum::routing::post(bot_play::play),
+            axum::routing::get(bot_play::play),
         )
         .route(
             "/{api_version}/game/move",

--- a/gamey/src/lib.rs
+++ b/gamey/src/lib.rs
@@ -42,6 +42,6 @@ pub use gamey_error::*;
 pub use notation::*;
 pub use bot_server::*;
 pub use bot_server::service::{
-    BotSelection, DEFAULT_PUBLIC_BOT_ID, DEFAULT_PUBLIC_DIFFICULTY, resolve_public_bot_selection,
+    BotSelection, DEFAULT_PUBLIC_BOT_ID, resolve_public_bot_selection,
 };
 pub use game_server::{MoveTurnResponse, run_game_server};

--- a/gamey/tests/bot_server_tests.rs
+++ b/gamey/tests/bot_server_tests.rs
@@ -113,20 +113,13 @@ async fn test_choose_endpoint_with_partially_filled_board() {
 #[tokio::test]
 async fn test_play_endpoint_with_default_public_bot() {
     let app = test_app();
-    let request_body = serde_json::json!({
-        "size": 3,
-        "turn": 0,
-        "players": ["B", "R"],
-        "layout": "./../..."
-    });
 
     let response = app
         .oneshot(
             Request::builder()
-                .method("POST")
-                .uri("/v1/ybot/play")
-                .header("content-type", "application/json")
-                .body(Body::from(request_body.to_string()))
+                .method("GET")
+                .uri("/v1/ybot/play?position=%7B%22size%22%3A3%2C%22turn%22%3A0%2C%22players%22%3A%5B%22B%22%2C%22R%22%5D%2C%22layout%22%3A%22.%2F..%2F...%22%7D")
+                .body(Body::empty())
                 .unwrap(),
         )
         .await
@@ -137,27 +130,19 @@ async fn test_play_endpoint_with_default_public_bot() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let play_response: PlayResponse = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(play_response.size(), 3);
-    assert_eq!(play_response.turn(), 1);
+    assert!(play_response.coords.x() + play_response.coords.y() + play_response.coords.z() == 2);
 }
 
 #[tokio::test]
 async fn test_game_server_router_exposes_ybot_play_endpoint() {
     let app = game_server::create_router(create_default_state());
-    let request_body = serde_json::json!({
-        "size": 3,
-        "turn": 0,
-        "players": ["B", "R"],
-        "layout": "./../..."
-    });
 
     let response = app
         .oneshot(
             Request::builder()
-                .method("POST")
-                .uri("/v1/ybot/play")
-                .header("content-type", "application/json")
-                .body(Body::from(request_body.to_string()))
+                .method("GET")
+                .uri("/v1/ybot/play?position=%7B%22size%22%3A3%2C%22turn%22%3A0%2C%22players%22%3A%5B%22B%22%2C%22R%22%5D%2C%22layout%22%3A%22.%2F..%2F...%22%7D")
+                .body(Body::empty())
                 .unwrap(),
         )
         .await
@@ -167,26 +152,15 @@ async fn test_game_server_router_exposes_ybot_play_endpoint() {
 }
 
 #[tokio::test]
-async fn test_play_endpoint_with_explicit_public_bot_and_difficulty() {
+async fn test_play_endpoint_with_explicit_public_bot() {
     let app = test_app();
-    let request_body = serde_json::json!({
-        "position": {
-            "size": 3,
-            "turn": 0,
-            "players": ["B", "R"],
-            "layout": "./../..."
-        },
-        "bot_id": "random_bot",
-        "difficulty": "Medium"
-    });
 
     let response = app
         .oneshot(
             Request::builder()
-                .method("POST")
-                .uri("/v1/ybot/play")
-                .header("content-type", "application/json")
-                .body(Body::from(request_body.to_string()))
+                .method("GET")
+                .uri("/v1/ybot/play?position=%7B%22size%22%3A3%2C%22turn%22%3A0%2C%22players%22%3A%5B%22B%22%2C%22R%22%5D%2C%22layout%22%3A%22.%2F..%2F...%22%7D&bot_id=smart_bot")
+                .body(Body::empty())
                 .unwrap(),
         )
         .await
@@ -197,67 +171,19 @@ async fn test_play_endpoint_with_explicit_public_bot_and_difficulty() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let play_response: PlayResponse = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(play_response.size(), 3);
-    assert_eq!(play_response.turn(), 1);
+    assert!(play_response.coords.x() + play_response.coords.y() + play_response.coords.z() == 2);
 }
 
 #[tokio::test]
-async fn test_play_endpoint_with_finished_game_returns_same_position() {
+async fn test_play_endpoint_with_finished_game_returns_error_when_there_is_no_move() {
     let app = test_app();
-    let request_body = serde_json::json!({
-        "position": {
-            "size": 2,
-            "turn": 0,
-            "players": ["B", "R"],
-            "layout": "B/RB"
-        }
-    });
 
     let response = app
         .oneshot(
             Request::builder()
-                .method("POST")
-                .uri("/v1/ybot/play")
-                .header("content-type", "application/json")
-                .body(Body::from(request_body.to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body = response.into_body().collect().await.unwrap().to_bytes();
-    let play_response: PlayResponse = serde_json::from_slice(&body).unwrap();
-
-    assert_eq!(play_response.layout(), "B/RB");
-    assert_eq!(play_response.turn(), 1);
-}
-
-// ============================================================================
-// Play endpoint tests - Error cases
-// ============================================================================
-
-#[tokio::test]
-async fn test_play_endpoint_rejects_unknown_difficulty() {
-    let app = test_app();
-    let request_body = serde_json::json!({
-        "position": {
-            "size": 3,
-            "turn": 0,
-            "players": ["B", "R"],
-            "layout": "./../..."
-        },
-        "difficulty": "Impossible"
-    });
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/ybot/play")
-                .header("content-type", "application/json")
-                .body(Body::from(request_body.to_string()))
+                .method("GET")
+                .uri("/v1/ybot/play?position=%7B%22size%22%3A2%2C%22turn%22%3A0%2C%22players%22%3A%5B%22B%22%2C%22R%22%5D%2C%22layout%22%3A%22B%2FRB%22%7D")
+                .body(Body::empty())
                 .unwrap(),
         )
         .await
@@ -267,7 +193,55 @@ async fn test_play_endpoint_rejects_unknown_difficulty() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let error_response: ErrorResponse = serde_json::from_slice(&body).unwrap();
-    assert!(error_response.message.contains("Unknown difficulty"));
+    assert!(error_response.message.contains("No valid moves available"));
+}
+
+// ============================================================================
+// Play endpoint tests - Error cases
+// ============================================================================
+
+#[tokio::test]
+async fn test_play_endpoint_rejects_unknown_bot() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/ybot/play?position=%7B%22size%22%3A3%2C%22turn%22%3A0%2C%22players%22%3A%5B%22B%22%2C%22R%22%5D%2C%22layout%22%3A%22.%2F..%2F...%22%7D&bot_id=random_bot")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let error_response: ErrorResponse = serde_json::from_slice(&body).unwrap();
+    assert!(error_response.message.contains("Unknown bot_id"));
+}
+
+#[tokio::test]
+async fn test_play_endpoint_rejects_invalid_position_json() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/ybot/play?position=not-json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let error_response: ErrorResponse = serde_json::from_slice(&body).unwrap();
+    assert!(error_response.message.contains("Invalid YEN format"));
 }
 
 // ============================================================================

--- a/gatewayservice/__tests__/gateway-service.test.js
+++ b/gatewayservice/__tests__/gateway-service.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'; 
 const request = require('supertest');
 const axios = require('axios');
-const { app, resolvePublicBotConfig } = require('../gateway-service');
+const { app, parseYenPosition, resolvePublicBotConfig } = require('../gateway-service');
 
 vi.mock('axios');
 
@@ -157,125 +157,123 @@ describe('Gateway Service - Bot play API', () => {
 
     it('should resolve public bot defaults for tournament play', () => {
         expect(resolvePublicBotConfig()).toEqual({
-            bot_id: 'center_bot',
-            difficulty: 'Hard',
-            registry_bot_id: 'center_bot',
+            bot_id: 'alpha_bot',
+            registry_bot_id: 'alpha_bot',
         });
     });
 
-    it('should route POST /play to the Rust play endpoint with defaults', async () => {
-        axios.post = vi.fn();
+    it('should parse a valid YEN query payload', () => {
+        expect(parseYenPosition('{"size":3,"turn":0,"players":["B","R"],"layout":"./../..."}')).toEqual({
+            position: {
+                size: 3,
+                turn: 0,
+                players: ['B', 'R'],
+                layout: './../...'
+            }
+        });
+    });
+
+    it('should route GET /play to the Rust play endpoint with defaults', async () => {
+        axios.get = vi.fn();
         const mockResponse = {
             data: {
-                size: 3,
-                turn: 1,
-                players: ['B', 'R'],
-                layout: 'B/../...'
+                coords: { x: 1, y: 1, z: 0 }
             }
         };
-        axios.post.mockResolvedValueOnce(mockResponse);
+        axios.get.mockResolvedValueOnce(mockResponse);
 
-        const position = {
-            size: 3,
-            turn: 0,
-            players: ['B', 'R'],
-            layout: './../...'
-        };
+        const position = '{"size":3,"turn":0,"players":["B","R"],"layout":"./../..."}';
 
         const res = await request(app)
-            .post('/play')
-            .send(position);
+            .get('/play')
+            .query({ position });
 
         expect(res.status).toBe(200);
-        expect(res.body.turn).toBe(1);
-        expect(res.body.layout).toBe('B/../...');
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(res.body).toEqual({ coords: { x: 1, y: 1, z: 0 } });
+        expect(axios.get).toHaveBeenCalledWith(
             expect.stringContaining('/v1/ybot/play'),
-            {
-                position,
-                bot_id: 'center_bot',
-                difficulty: 'Hard',
-            }
+            expect.objectContaining({
+                params: {
+                    position,
+                    bot_id: 'alpha_bot',
+                }
+            })
         );
     });
 
-    it('should still route POST /play with the legacy position wrapper', async () => {
-        axios.post = vi.fn();
-        axios.post.mockResolvedValueOnce({
-            data: {
-                size: 3,
-                turn: 1,
-                players: ['B', 'R'],
-                layout: 'B/../...'
-            }
+    it('should route GET /play with an explicit public bot', async () => {
+        axios.get = vi.fn();
+        axios.get.mockResolvedValueOnce({
+            data: { coords: { x: 0, y: 2, z: 0 } }
         });
 
-        const position = {
-            size: 3,
-            turn: 0,
-            players: ['B', 'R'],
-            layout: './../...'
-        };
+        const position = '{"size":3,"turn":0,"players":["B","R"],"layout":"./../..."}';
 
         const res = await request(app)
-            .post('/play')
-            .send({ position });
+            .get('/play')
+            .query({ position, bot_id: 'smart_bot' });
 
         expect(res.status).toBe(200);
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(axios.get).toHaveBeenCalledWith(
             expect.stringContaining('/v1/ybot/play'),
-            {
-                position,
-                bot_id: 'center_bot',
-                difficulty: 'Hard',
-            }
+            expect.objectContaining({
+                params: {
+                    position,
+                    bot_id: 'smart_bot',
+                }
+            })
         );
     });
 
-    it('should reject POST /play when YEN position is missing', async () => {
+    it('should reject GET /play when YEN position is missing', async () => {
         const res = await request(app)
-            .post('/play')
-            .send({ bot_id: 'center_bot' });
+            .get('/play')
+            .query({ bot_id: 'alpha_bot' });
 
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('YEN position is required');
     });
 
-    it('should reject POST /play with unknown difficulty', async () => {
+    it('should reject GET /play when YEN position is not valid JSON', async () => {
         const res = await request(app)
-            .post('/play')
-            .send({
-                position: {
-                    size: 3,
-                    turn: 0,
-                    players: ['B', 'R'],
-                    layout: './../...'
-                },
-                difficulty: 'Impossible'
+            .get('/play')
+            .query({ position: 'not-json' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('YEN position must be valid JSON');
+    });
+
+    it('should reject GET /play with an unknown public bot', async () => {
+        const res = await request(app)
+            .get('/play')
+            .query({
+                position: '{"size":3,"turn":0,"players":["B","R"],"layout":"./../..."}',
+                bot_id: 'random_bot'
             });
 
         expect(res.status).toBe(400);
-        expect(res.body.error).toContain('Unknown difficulty');
+        expect(res.body.error).toContain('Unknown bot_id');
     });
 
-    it('should forward backend errors from POST /play', async () => {
-        axios.post = vi.fn();
-        axios.post.mockRejectedValueOnce({
+    it('should forward backend errors from GET /play', async () => {
+        axios.get = vi.fn();
+        axios.get.mockRejectedValueOnce({
             response: { status: 400, data: { message: 'Invalid YEN format' } }
         });
 
         const res = await request(app)
-            .post('/play')
-            .send({
-                position: {
-                    size: 3,
-                    turn: 0,
-                    players: ['B', 'R'],
-                    layout: 'invalid'
-                }
+            .get('/play')
+            .query({
+                position: '{"size":3,"turn":0,"players":["B","R"],"layout":"invalid"}'
             });
 
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('Invalid YEN format');
+    });
+
+    it('should reject incomplete YEN payloads', async () => {
+        expect(parseYenPosition('{"size":3,"turn":0}')).toEqual({
+            error: 'YEN position is required'
+        });
     });
 });

--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -162,22 +162,30 @@ app.get('/game/status', async (req, res) => {
 
 
 const VALID_BOTS        = new Set(['random_bot', 'center_bot', 'edge_bot','smart_bot', 'mirror_bot','alpha_bot']);
-const VALID_DIFFICULTIES = new Set(['Easy', 'Medium', 'Hard']);
-const DIFFICULTY_SUFFIX = { Easy: '_1', Medium: '_2', Hard: '' };
-const DEFAULT_PUBLIC_BOT_ID = 'center_bot';
-const DEFAULT_PUBLIC_DIFFICULTY = 'Hard';
+const PUBLIC_TOURNAMENT_BOTS = new Set(['alpha_bot', 'smart_bot']);
+const DEFAULT_PUBLIC_BOT_ID = 'alpha_bot';
 
-function resolveBotName(bot_id, difficulty) {
-  return bot_id + DIFFICULTY_SUFFIX[difficulty];
+function resolvePublicBotConfig(bot_id) {
+  const resolvedBotId = bot_id || DEFAULT_PUBLIC_BOT_ID;
+  if (!PUBLIC_TOURNAMENT_BOTS.has(resolvedBotId)) {
+    return { error: `Unknown bot_id: ${resolvedBotId}` };
+  }
+
+  return {
+    bot_id: resolvedBotId,
+    registry_bot_id: resolvedBotId,
+  };
 }
 
-function resolvePublicBotConfig(bot_id, difficulty) {
-  const resolvedBotId = bot_id || DEFAULT_PUBLIC_BOT_ID;
+function resolveGameMoveBotConfig(bot_id, difficulty) {
+  const resolvedBotId = bot_id || 'random_bot';
   if (!VALID_BOTS.has(resolvedBotId)) {
     return { error: `Unknown bot_id: ${resolvedBotId}` };
   }
 
-  const resolvedDifficulty = difficulty || DEFAULT_PUBLIC_DIFFICULTY;
+  const VALID_DIFFICULTIES = new Set(['Easy', 'Medium', 'Hard']);
+  const DIFFICULTY_SUFFIX = { Easy: '_1', Medium: '_2', Hard: '' };
+  const resolvedDifficulty = difficulty || 'Medium';
   if (!VALID_DIFFICULTIES.has(resolvedDifficulty)) {
     return { error: `Unknown difficulty: ${resolvedDifficulty}` };
   }
@@ -185,7 +193,7 @@ function resolvePublicBotConfig(bot_id, difficulty) {
   return {
     bot_id: resolvedBotId,
     difficulty: resolvedDifficulty,
-    registry_bot_id: resolveBotName(resolvedBotId, resolvedDifficulty),
+    registry_bot_id: resolvedBotId + DIFFICULTY_SUFFIX[resolvedDifficulty],
   };
 }
 
@@ -194,7 +202,7 @@ app.post('/game/move', async (req, res) => {
     const { mode, bot_id, difficulty } = req.body;
  
     if (mode === 'bot') {
-      const resolvedBot = resolvePublicBotConfig(bot_id || 'random_bot', difficulty || 'Medium');
+      const resolvedBot = resolveGameMoveBotConfig(bot_id, difficulty);
       if (resolvedBot.error) {
         return res.status(400).json({ error: resolvedBot.error });
       }
@@ -211,32 +219,47 @@ app.post('/game/move', async (req, res) => {
   }
 });
 
-app.post('/play', async (req, res) => {
-  try {
-    const { bot_id, difficulty } = req.body;
-    const rawPosition = req.body.position || req.body;
+function parseYenPosition(rawPosition) {
+  if (!rawPosition) {
+    return { error: 'YEN position is required' };
+  }
 
-    if (!rawPosition || rawPosition.size === undefined || rawPosition.turn === undefined || !rawPosition.players || !rawPosition.layout) {
-      return res.status(400).json({ error: 'YEN position is required' });
+  try {
+    const position = JSON.parse(rawPosition);
+    if (
+      position.size === undefined ||
+      position.turn === undefined ||
+      !position.players ||
+      !position.layout
+    ) {
+      return { error: 'YEN position is required' };
     }
 
-    const position = {
-      size: rawPosition.size,
-      turn: rawPosition.turn,
-      players: rawPosition.players,
-      layout: rawPosition.layout,
-    };
+    return { position };
+  } catch {
+    return { error: 'YEN position must be valid JSON' };
+  }
+}
 
-    const resolvedBot = resolvePublicBotConfig(bot_id, difficulty);
+app.get('/play', async (req, res) => {
+  try {
+    const { bot_id, position: rawPosition } = req.query;
+    const parsed = parseYenPosition(rawPosition);
+    if (parsed.error) {
+      return res.status(400).json({ error: parsed.error });
+    }
+
+    const resolvedBot = resolvePublicBotConfig(bot_id);
     if (resolvedBot.error) {
       return res.status(400).json({ error: resolvedBot.error });
     }
 
     const playUrl = new URL('/v1/ybot/play', gameyServiceUrl);
-    const response = await axios.post(playUrl.href, {
-      position,
-      bot_id: resolvedBot.bot_id,
-      difficulty: resolvedBot.difficulty,
+    const response = await axios.get(playUrl.href, {
+      params: {
+        position: JSON.stringify(parsed.position),
+        bot_id: resolvedBot.bot_id,
+      },
     });
 
     res.status(200).json(response.data);
@@ -248,5 +271,5 @@ app.post('/play', async (req, res) => {
 
 const server = app.listen(port, () => console.log(`Gateway listening on ${port}`))
 
-module.exports = { app, server, resolveBotName, resolvePublicBotConfig }
+module.exports = { app, server, parseYenPosition, resolveGameMoveBotConfig, resolvePublicBotConfig }
 

--- a/gatewayservice/openapi.yaml
+++ b/gatewayservice/openapi.yaml
@@ -195,7 +195,10 @@ paths:
                   enum:
                     - random_bot
                     - center_bot
+                    - smart_bot
                     - edge_bot
+                    - mirror_bot
+                    - alpha_bot
                   default: random_bot
                   description: Identificador del bot (obligatorio y validado si el mode es 'bot')
                 difficulty:
@@ -215,69 +218,48 @@ paths:
           description: Error interno del servidor
 
   /play:
-    post:
-      summary: Ejecuta una jugada del bot sobre una posicion YEN
-      description: Recibe una posicion YEN directamente y devuelve la posicion YEN resultante tras aplicar la jugada del bot. Por defecto usa center_bot en dificultad Hard.
+    get:
+      summary: Devuelve la siguiente jugada del bot para una posicion YEN
+      description: API publica estandar para el torneo. Recibe la posicion actual serializada en YEN como query parameter y devuelve unas coordenadas. Por defecto usa alpha_bot.
       tags:
         - Bot API
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - size
-                - turn
-                - players
-                - layout
-              properties:
-                size:
-                  type: integer
-                  example: 3
-                turn:
-                  type: integer
-                  example: 0
-                players:
-                  type: array
-                  items:
-                    type: string
-                  example:
-                    - B
-                    - R
-                layout:
-                  type: string
-                  example: ./../...
-            example:
-              size: 3
-              turn: 0
-              players:
-                - B
-                - R
-              layout: ./../...
+      parameters:
+        - in: query
+          name: position
+          required: true
+          schema:
+            type: string
+          description: Posicion del tablero en formato YEN serializada como JSON
+          example: '{"size":3,"turn":0,"players":["B","R"],"layout":"./../..."}'
+        - in: query
+          name: bot_id
+          required: false
+          schema:
+            type: string
+            enum:
+              - alpha_bot
+              - smart_bot
+            default: alpha_bot
+          description: Identificador del bot publico a utilizar
       responses:
         '200':
-          description: Posicion YEN resultante tras la jugada del bot
+          description: Coordenadas de la siguiente jugada del bot
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  size:
-                    type: integer
-                    example: 3
-                  turn:
-                    type: integer
-                    example: 1
-                  players:
-                    type: array
-                    items:
-                      type: string
-                    example:
-                      - B
-                      - R
-                  layout:
-                    type: string
-                    example: B/../...
+                  coords:
+                    type: object
+                    properties:
+                      x:
+                        type: integer
+                        example: 1
+                      y:
+                        type: integer
+                        example: 1
+                      z:
+                        type: integer
+                        example: 0
         '400':
           description: Peticion invalida o error propagado desde Gamey


### PR DESCRIPTION
- Adaptada la API interna del bot al nuevo contrato play con GET, deja de aplicar la jugada al tablero y pasa a devolver únicamente las coordenadas del siguiente movimiento.
- Se simplifica la resolución de bots públicos para usar siempre la variante Hard, fijando alpha_bot como bot por defecto y smart_bot como segunda opción pública.
- Se actualiza el gateway para exponer la nueva API pública estándar del torneo mediante GET /play, usando position como parametro en formato YEN y bot_id opcional.
- Se actualiza la documentación OpenAPI del gateway para reflejar el contrato final de la API pública del bot.