### PR TITLE
Añadido test e2e para partida pvp

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ To run the project locally without Docker, you will need to run each component i
 #### Prerequisites
 
 * [Node.js](https://nodejs.org/) and npm installed.
+* [Docker](https://www.docker.com/) available if you run the end-to-end tests locally.
+* A `JWT_SECRET` value configured in the environment for local login flows.
+* On Windows, if `gamey` fails with `dlltool.exe: program not found`, use the MSVC Rust toolchain or install the GNU binutils that provide `dlltool.exe`.
 
 #### 1. Running the User Service
 
@@ -165,8 +168,10 @@ Each component has its own set of scripts defined in its `package.json`. Here ar
 
 - `npm run dev`: Starts the development server for the webapp.
 - `npm test`: Runs the unit tests.
-- `npm run test:e2e`: Runs the end-to-end tests.
-- `npm run start:all`: A convenience script to start both the `webapp` and the `users` service concurrently.
+- `npm run test:e2e:services`: Starts MongoDB and `gamey` with Docker Compose for end-to-end tests.
+- `npm run test:e2e`: Starts MongoDB and `gamey` with Docker Compose, starts the app services, and runs the end-to-end tests.
+- `npm run test:e2e:run`: Runs only the Cucumber end-to-end tests against already running services.
+- `npm run start:all`: A convenience script to start the `webapp`, `users`, `gatewayservice`, and `gamey` services concurrently.
 
 ### Gateway (`gatewayservice/package.json`)
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,8 +12,11 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "test:e2e:run": "cucumber-js --import test/e2e/support/setup.mjs --import test/e2e/steps/**/*.mjs test/e2e/features --format progress",
-    "test:e2e": "start-server-and-test start:all http://localhost:5173 test:e2e:run",
+    "test:e2e:services": "docker compose -f ../docker-compose.yml up -d mongodb gamey",
+    "pretest:e2e": "npm run test:e2e:services",
+    "test:e2e": "start-server-and-test start:all:e2e http://localhost:5173 test:e2e:run",
     "test:e2e:install-browsers": "npx playwright install",
+    "start:all:e2e": "concurrently \"npm run dev\" \"npm --prefix ../users start\" \"npm --prefix ../gatewayservice start\"",
     "start:all": "concurrently \"npm run dev\" \"npm --prefix ../users start\" \"npm --prefix ../gatewayservice start\" \"cargo run --manifest-path ../gamey/Cargo.toml -- --mode server --port 4000\""
   },
   "dependencies": {

--- a/webapp/src/SessionContext.tsx
+++ b/webapp/src/SessionContext.tsx
@@ -16,9 +16,11 @@ interface SessionProviderProps {
 }
 
 const SessionProvider: React.FC<SessionProviderProps> = ({ children }) => {
-  const [sessionId, setSessionId] = useState<string>('');
-  const [username, setUsername] = useState<string>('');
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const [sessionId, setSessionId] = useState<string>(() => localStorage.getItem('sessionId') || '');
+  const [username, setUsername] = useState<string>(() => localStorage.getItem('username') || '');
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(() => {
+    return Boolean(localStorage.getItem('sessionId') && localStorage.getItem('username'));
+  });
 
   // Retrieves data from localstorage on startup
   useEffect(() => {

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -318,6 +318,7 @@ export default function GamePage() {
     isActive: boolean,
     touchedSides: { touchesA: boolean; touchesB: boolean; touchesC: boolean },
   ) => {
+    const playerTestId = label.toLowerCase().replace(/\s+/g, '-')
     const triangle = getTriangleVertices()
     const stroke = color === 'B' ? '#1565c0' : '#c62828'
     const fill = color === 'B' ? 'rgba(21, 101, 192, 0.14)' : 'rgba(198, 40, 40, 0.14)'
@@ -327,6 +328,7 @@ export default function GamePage() {
 
     return (
       <Paper
+        data-testid={`${playerTestId}-card`}
         elevation={0}
         sx={{
           flex: 1,
@@ -342,6 +344,7 @@ export default function GamePage() {
             {label}
           </Typography>
           <Box
+            data-testid={`${playerTestId}-status`}
             sx={{
               px: 1,
               py: 0.35,
@@ -587,6 +590,8 @@ export default function GamePage() {
                   
                   return (
                     <g
+                      data-testid={`cell-${rowIndex}-${cellIndex}`}
+                      aria-label={`Cell ${rowIndex} ${cellIndex}`}
                       key={`${rowIndex}-${cellIndex}`}
                       onClick={() => {
                         if (clickable) {

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -318,7 +318,7 @@ export default function GamePage() {
     isActive: boolean,
     touchedSides: { touchesA: boolean; touchesB: boolean; touchesC: boolean },
   ) => {
-    const playerTestId = label.toLowerCase().replace(/\s+/g, '-')
+    const playerTestId = label.toLowerCase().replaceAll(/\s+/g, '-')
     const triangle = getTriangleVertices()
     const stroke = color === 'B' ? '#1565c0' : '#c62828'
     const fill = color === 'B' ? 'rgba(21, 101, 192, 0.14)' : 'rgba(198, 40, 40, 0.14)'

--- a/webapp/src/pages/GameSetup.tsx
+++ b/webapp/src/pages/GameSetup.tsx
@@ -362,7 +362,7 @@ const GameSetup = () => {
       <DivRow>
         {/* ── Modo PvP ── */}
         <DivColumn>
-          <ModeButton variant="outlined" onClick={handleStartPvp}>
+          <ModeButton data-testid="start-pvp-game" variant="outlined" onClick={handleStartPvp}>
             ▲ Player vs Player ▲
           </ModeButton>
           <ModeDescription>Play locally against a friend</ModeDescription>

--- a/webapp/test/e2e/features/game-pvp.feature
+++ b/webapp/test/e2e/features/game-pvp.feature
@@ -1,14 +1,20 @@
 Feature: Player vs Player game
   Validate a local player vs player game
 
-  Scenario: Start a Player vs Player game and play two turns
+  Scenario: Start a Player vs Player game and finish with Player 1 winning
     Given a logged in game player
     And a small board size is selected
     And the game setup page is open
     When I start a Player vs Player game
     Then I should see the Player vs Player board
     And it should be Player 1 turn
-    When Player 1 places a piece on cell "0-0"
+    When Player 1 places a piece on cell "2-0"
     Then it should be Player 2 turn
-    When Player 2 places a piece on cell "1-0"
+    When Player 2 places a piece on cell "0-0"
     Then it should be Player 1 turn
+    When Player 1 places a piece on cell "2-1"
+    Then it should be Player 2 turn
+    When Player 2 places a piece on cell "1-1"
+    Then it should be Player 1 turn
+    When Player 1 places a piece on cell "2-2"
+    Then Player 1 should win the game

--- a/webapp/test/e2e/features/game-pvp.feature
+++ b/webapp/test/e2e/features/game-pvp.feature
@@ -1,0 +1,14 @@
+Feature: Player vs Player game
+  Validate a local player vs player game
+
+  Scenario: Start a Player vs Player game and play two turns
+    Given a logged in game player
+    And a small board size is selected
+    And the game setup page is open
+    When I start a Player vs Player game
+    Then I should see the Player vs Player board
+    And it should be Player 1 turn
+    When Player 1 places a piece on cell "0-0"
+    Then it should be Player 2 turn
+    When Player 2 places a piece on cell "1-0"
+    Then it should be Player 1 turn

--- a/webapp/test/e2e/steps/game-pvp.steps.mjs
+++ b/webapp/test/e2e/steps/game-pvp.steps.mjs
@@ -1,0 +1,93 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import assert from 'assert'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5173'
+
+async function waitForPlayerTurn(page, playerTestId) {
+  await page.waitForFunction(
+    (testId) => document.querySelector(`[data-testid="${testId}"]`)?.textContent?.trim() === 'Turn',
+    playerTestId,
+    { timeout: 15000 },
+  )
+}
+
+Given('a logged in game player', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  const username = `game_${Date.now()}`
+  const password = 'Password123!'
+
+  await page.goto(`${BASE_URL}/register`)
+  await page.fill('input[name="username"]', username)
+  await page.fill('input[name="name"]', 'Game')
+  await page.fill('input[name="surname"]', 'Player')
+  await page.fill('input[name="email"]', `${username}@test.com`)
+  await page.fill('input[name="password"]', password)
+  await page.fill('input[name="confirmPassword"]', password)
+  await page.click('button:has-text("Register")')
+  await page.waitForURL('**/homepage', { timeout: 15000 })
+})
+
+Given('a small board size is selected', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.evaluate(() => {
+    window.sessionStorage.setItem('boardSize', '3')
+  })
+})
+
+Given('the game setup page is open', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.getByRole('button', { name: /Play/i }).click()
+  await page.getByTestId('start-pvp-game').waitFor({ state: 'visible', timeout: 15000 })
+})
+
+When('I start a Player vs Player game', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.getByTestId('start-pvp-game').click()
+})
+
+Then('I should see the Player vs Player board', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.getByRole('heading', { name: /Game Y - Player vs Player/i }).waitFor({ state: 'visible', timeout: 15000 })
+  await page.locator('svg[aria-label="Y game board"]').waitFor({ state: 'visible', timeout: 15000 })
+
+  const cells = await page.locator('[data-testid^="cell-"]').count()
+  assert.equal(cells, 6, `Expected a size 3 board to have 6 cells, got ${cells}`)
+})
+
+Then('it should be Player 1 turn', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await waitForPlayerTurn(page, 'player-1-status')
+})
+
+Then('it should be Player 2 turn', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await waitForPlayerTurn(page, 'player-2-status')
+})
+
+When('Player 1 places a piece on cell {string}', async function (cell) {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.getByTestId(`cell-${cell}`).click()
+})
+
+When('Player 2 places a piece on cell {string}', async function (cell) {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.getByTestId(`cell-${cell}`).click()
+})

--- a/webapp/test/e2e/steps/game-pvp.steps.mjs
+++ b/webapp/test/e2e/steps/game-pvp.steps.mjs
@@ -91,3 +91,11 @@ When('Player 2 places a piece on cell {string}', async function (cell) {
 
   await page.getByTestId(`cell-${cell}`).click()
 })
+
+Then('Player 1 should win the game', async function () {
+  const page = this.page
+  if (!page) throw new Error('Page not initialized')
+
+  await page.getByRole('heading', { name: 'Player B wins!' }).waitFor({ state: 'visible', timeout: 15000 })
+  await page.getByText('The game has ended. Player blue wins.').waitFor({ state: 'visible', timeout: 15000 })
+})


### PR DESCRIPTION
Añadido un test e2e completo para el modo Player vs Player. El escenario registra un usuario, selecciona un tablero de tamaño 3, inicia una partida local, valida la alternancia de turnos y juega una secuencia completa hasta que Player 1 gana. También se añadieron selectores estables en la configuración y en el tablero para interactuar con Playwright sin depender de coordenadas SVG.